### PR TITLE
[BE] 카드 목록 조회

### DIFF
--- a/backend/src/main/java/kr/codesquad/todo/controller/CardController.java
+++ b/backend/src/main/java/kr/codesquad/todo/controller/CardController.java
@@ -48,4 +48,10 @@ public class CardController {
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(cardService.retrieveAll());
 	}
+
+	@GetMapping(params = "categoryId")
+	public ResponseEntity<CardsResponse> retrieveOne(@RequestParam Long categoryId) {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(cardService.retrieveOne(categoryId));
+	}
 }

--- a/backend/src/main/java/kr/codesquad/todo/controller/CardController.java
+++ b/backend/src/main/java/kr/codesquad/todo/controller/CardController.java
@@ -1,11 +1,13 @@
 package kr.codesquad.todo.controller;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import kr.codesquad.todo.dto.request.CardCreationRequest;
+import kr.codesquad.todo.dto.response.CardsResponse;
 import kr.codesquad.todo.service.CardService;
 
 @RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE, path = "/api/cards")
@@ -38,5 +41,11 @@ public class CardController {
 	public ResponseEntity<Void> delete(@PathVariable Long cardId) {
 		cardService.delete(cardId);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	@GetMapping
+	public ResponseEntity<List<CardsResponse>> retrieveAll() {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(cardService.retrieveAll());
 	}
 }

--- a/backend/src/main/java/kr/codesquad/todo/dto/response/CardData.java
+++ b/backend/src/main/java/kr/codesquad/todo/dto/response/CardData.java
@@ -1,0 +1,49 @@
+package kr.codesquad.todo.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class CardData {
+
+	private final Long id;
+	private final String title;
+	private final String content;
+	private final String nickname;
+	private final Long prevCardId;
+	private final CategoryResponse categoryResponse;
+
+	public CardData(Long id, String title, String content, String nickname, Long prevCardId,
+		CategoryResponse categoryResponse) {
+		this.id = id;
+		this.title = title;
+		this.content = content;
+		this.nickname = nickname;
+		this.prevCardId = prevCardId;
+		this.categoryResponse = categoryResponse;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public String getNickname() {
+		return nickname;
+	}
+
+	@JsonIgnore
+	public Long getPrevCardId() {
+		return prevCardId;
+	}
+
+	@JsonIgnore
+	public CategoryResponse getCategoryResponse() {
+		return categoryResponse;
+	}
+}

--- a/backend/src/main/java/kr/codesquad/todo/dto/response/CardsResponse.java
+++ b/backend/src/main/java/kr/codesquad/todo/dto/response/CardsResponse.java
@@ -6,6 +6,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import kr.codesquad.todo.exeption.BusinessException;
+import kr.codesquad.todo.exeption.ErrorCode;
+
 public class CardsResponse {
 
 	private final Long categoryId;
@@ -18,12 +21,21 @@ public class CardsResponse {
 		this.cards = cards;
 	}
 
-	public static List<CardsResponse> from(List<CardData> cardData) {
+	public static List<CardsResponse> listFrom(List<CardData> cardData) {
 		Map<CategoryResponse, List<CardData>> groupingCardData = cardData.stream()
 			.collect(Collectors.groupingBy(CardData::getCategoryResponse));
 		return groupingCardData.entrySet().stream()
 			.map(CardsResponse::from)
 			.collect(Collectors.toList());
+	}
+
+	public static CardsResponse singleFrom(List<CardData> cardData) {
+		Map<CategoryResponse, List<CardData>> card = cardData.stream()
+			.collect(Collectors.groupingBy(CardData::getCategoryResponse));
+		return card.entrySet().stream()
+			.map(CardsResponse::from)
+			.findFirst()
+			.orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
 	}
 
 	private static CardsResponse from(Map.Entry<CategoryResponse, List<CardData>> entry) {

--- a/backend/src/main/java/kr/codesquad/todo/dto/response/CardsResponse.java
+++ b/backend/src/main/java/kr/codesquad/todo/dto/response/CardsResponse.java
@@ -1,0 +1,63 @@
+package kr.codesquad.todo.dto.response;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class CardsResponse {
+
+	private final Long categoryId;
+	private final String categoryName;
+	private final List<CardData> cards;
+
+	public CardsResponse(Long categoryId, String categoryName, List<CardData> cards) {
+		this.categoryId = categoryId;
+		this.categoryName = categoryName;
+		this.cards = cards;
+	}
+
+	public static List<CardsResponse> from(List<CardData> cardData) {
+		Map<CategoryResponse, List<CardData>> groupingCardData = cardData.stream()
+			.collect(Collectors.groupingBy(CardData::getCategoryResponse));
+		return groupingCardData.entrySet().stream()
+			.map(CardsResponse::from)
+			.collect(Collectors.toList());
+	}
+
+	private static CardsResponse from(Map.Entry<CategoryResponse, List<CardData>> entry) {
+		return new CardsResponse(entry.getKey().getCategoryId(), entry.getKey().getCategoryName(),
+			sort(entry.getValue()));
+	}
+
+	private static List<CardData> sort(List<CardData> cardsData) {
+		List<CardData> answer = new ArrayList<>();
+		if (cardsData.size() == 1 && cardsData.get(0).getId() == 0L) {
+			return answer;
+		}
+		Long prevId = 0L;
+		for (int i = 0; i < cardsData.size(); i++) {
+			for (CardData cardsDatum : cardsData) {
+				if (Objects.equals(cardsDatum.getPrevCardId(), prevId)) {
+					answer.add(cardsDatum);
+					prevId = cardsDatum.getId();
+					break;
+				}
+			}
+		}
+		return answer;
+	}
+
+	public Long getCategoryId() {
+		return categoryId;
+	}
+
+	public String getCategoryName() {
+		return categoryName;
+	}
+
+	public List<CardData> getCards() {
+		return cards;
+	}
+}

--- a/backend/src/main/java/kr/codesquad/todo/dto/response/CategoryResponse.java
+++ b/backend/src/main/java/kr/codesquad/todo/dto/response/CategoryResponse.java
@@ -1,0 +1,38 @@
+package kr.codesquad.todo.dto.response;
+
+import java.util.Objects;
+
+public class CategoryResponse {
+
+	private final Long categoryId;
+	private final String categoryName;
+
+	public CategoryResponse(Long categoryId, String categoryName) {
+		this.categoryId = categoryId;
+		this.categoryName = categoryName;
+	}
+
+	public Long getCategoryId() {
+		return categoryId;
+	}
+
+	public String getCategoryName() {
+		return categoryName;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		CategoryResponse that = (CategoryResponse)o;
+		return Objects.equals(categoryId, that.categoryId) && Objects.equals(categoryName,
+			that.categoryName);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(categoryId, categoryName);
+	}
+}

--- a/backend/src/main/java/kr/codesquad/todo/repository/CardRepository.java
+++ b/backend/src/main/java/kr/codesquad/todo/repository/CardRepository.java
@@ -23,6 +23,14 @@ public class CardRepository {
 	private final NamedParameterJdbcTemplate jdbcTemplate;
 	private final SimpleJdbcInsert simpleJdbcInsert;
 
+	private static final RowMapper<CardData> cardDataRowMapper = ((rs, rowNum) -> new CardData(
+		rs.getLong("id"),
+		rs.getString("title"),
+		rs.getString("content"),
+		rs.getString("nickname"),
+		rs.getLong("prev_card_id"),
+		new CategoryResponse(rs.getLong("category_id"), rs.getString("name"))));
+
 	public CardRepository(NamedParameterJdbcTemplate jdbcTemplate, DataSource dataSource) {
 		this.jdbcTemplate = jdbcTemplate;
 		this.simpleJdbcInsert = new SimpleJdbcInsert(dataSource)
@@ -79,17 +87,7 @@ public class CardRepository {
 				+ "RIGHT JOIN category cg ON c.category_id = cg.id "
 				+ "LEFT JOIN user_account u ON cg.user_account_id = u.id "
 				+ "WHERE u.id = 1";
-		return jdbcTemplate.query(findAll, cardDataRowMapper());
-	}
-
-	private RowMapper<CardData> cardDataRowMapper() {
-		return ((rs, rowNum) -> new CardData(
-			rs.getLong("id"),
-			rs.getString("title"),
-			rs.getString("content"),
-			rs.getString("nickname"),
-			rs.getLong("prev_card_id"),
-			new CategoryResponse(rs.getLong("category_id"), rs.getString("name"))));
+		return jdbcTemplate.query(findAll, cardDataRowMapper);
 	}
 
 	public List<CardData> findByCategoryId(Long categoryId) {
@@ -98,6 +96,6 @@ public class CardRepository {
 				+ "RIGHT JOIN category cg ON c.category_id = cg.id "
 				+ "LEFT JOIN user_account u ON cg.user_account_id = u.id "
 				+ "WHERE u.id = 1 AND cg.id = :categoryId";
-		return jdbcTemplate.query(findByCategoryId, Map.of("categoryId", categoryId), cardDataRowMapper());
+		return jdbcTemplate.query(findByCategoryId, Map.of("categoryId", categoryId), cardDataRowMapper);
 	}
 }

--- a/backend/src/main/java/kr/codesquad/todo/repository/CardRepository.java
+++ b/backend/src/main/java/kr/codesquad/todo/repository/CardRepository.java
@@ -1,17 +1,21 @@
 package kr.codesquad.todo.repository;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import javax.sql.DataSource;
 
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 
 import kr.codesquad.todo.domain.Card;
+import kr.codesquad.todo.dto.response.CardData;
+import kr.codesquad.todo.dto.response.CategoryResponse;
 
 @Repository
 public class CardRepository {
@@ -67,5 +71,24 @@ public class CardRepository {
 		} catch (EmptyResultDataAccessException e) {
 			return Optional.empty();
 		}
+	}
+
+	public List<CardData> findAll() {
+		String findAll =
+			"SELECT c.id, c.title, c.content, u.nickname, c.prev_card_id, cg.id as category_id, cg.name FROM card c "
+				+ "RIGHT JOIN category cg ON c.category_id = cg.id "
+				+ "LEFT JOIN user_account u ON cg.user_account_id = u.id "
+				+ "WHERE u.id = 1";
+		return jdbcTemplate.query(findAll, cardsForOrderResponseRowMapper());
+	}
+
+	private RowMapper<CardData> cardsForOrderResponseRowMapper() {
+		return ((rs, rowNum) -> new CardData(
+			rs.getLong("id"),
+			rs.getString("title"),
+			rs.getString("content"),
+			rs.getString("nickname"),
+			rs.getLong("prev_card_id"),
+			new CategoryResponse(rs.getLong("category_id"), rs.getString("name"))));
 	}
 }

--- a/backend/src/main/java/kr/codesquad/todo/repository/CardRepository.java
+++ b/backend/src/main/java/kr/codesquad/todo/repository/CardRepository.java
@@ -79,10 +79,10 @@ public class CardRepository {
 				+ "RIGHT JOIN category cg ON c.category_id = cg.id "
 				+ "LEFT JOIN user_account u ON cg.user_account_id = u.id "
 				+ "WHERE u.id = 1";
-		return jdbcTemplate.query(findAll, cardsForOrderResponseRowMapper());
+		return jdbcTemplate.query(findAll, cardDataRowMapper());
 	}
 
-	private RowMapper<CardData> cardsForOrderResponseRowMapper() {
+	private RowMapper<CardData> cardDataRowMapper() {
 		return ((rs, rowNum) -> new CardData(
 			rs.getLong("id"),
 			rs.getString("title"),
@@ -90,5 +90,14 @@ public class CardRepository {
 			rs.getString("nickname"),
 			rs.getLong("prev_card_id"),
 			new CategoryResponse(rs.getLong("category_id"), rs.getString("name"))));
+	}
+
+	public List<CardData> findByCategoryId(Long categoryId) {
+		String findByCategoryId =
+			"SELECT c.id, c.title, c.content, u.nickname, c.prev_card_id, cg.id as category_id, cg.name FROM card c "
+				+ "RIGHT JOIN category cg ON c.category_id = cg.id "
+				+ "LEFT JOIN user_account u ON cg.user_account_id = u.id "
+				+ "WHERE u.id = 1 AND cg.id = :categoryId";
+		return jdbcTemplate.query(findByCategoryId, Map.of("categoryId", categoryId), cardDataRowMapper());
 	}
 }

--- a/backend/src/main/java/kr/codesquad/todo/service/CardService.java
+++ b/backend/src/main/java/kr/codesquad/todo/service/CardService.java
@@ -54,7 +54,7 @@ public class CardService {
 		return CardsResponse.listFrom(cardData);
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public CardsResponse retrieveOne(Long categoryId) {
 		List<CardData> cardData = cardRepository.findByCategoryId(categoryId);
 		return CardsResponse.singleFrom(cardData);

--- a/backend/src/main/java/kr/codesquad/todo/service/CardService.java
+++ b/backend/src/main/java/kr/codesquad/todo/service/CardService.java
@@ -1,9 +1,13 @@
 package kr.codesquad.todo.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.codesquad.todo.dto.request.CardCreationRequest;
+import kr.codesquad.todo.dto.response.CardData;
+import kr.codesquad.todo.dto.response.CardsResponse;
 import kr.codesquad.todo.exeption.BusinessException;
 import kr.codesquad.todo.exeption.ErrorCode;
 import kr.codesquad.todo.repository.CardRepository;
@@ -42,5 +46,11 @@ public class CardService {
 		if (nextId != -1L) {
 			cardRepository.updateById(nextId, prevId);
 		}
+	}
+
+	@Transactional(readOnly = true)
+	public List<CardsResponse> retrieveAll() {
+		List<CardData> cardData = cardRepository.findAll();
+		return CardsResponse.from(cardData);
 	}
 }

--- a/backend/src/main/java/kr/codesquad/todo/service/CardService.java
+++ b/backend/src/main/java/kr/codesquad/todo/service/CardService.java
@@ -51,6 +51,12 @@ public class CardService {
 	@Transactional(readOnly = true)
 	public List<CardsResponse> retrieveAll() {
 		List<CardData> cardData = cardRepository.findAll();
-		return CardsResponse.from(cardData);
+		return CardsResponse.listFrom(cardData);
+	}
+
+	@Transactional
+	public CardsResponse retrieveOne(Long categoryId) {
+		List<CardData> cardData = cardRepository.findByCategoryId(categoryId);
+		return CardsResponse.singleFrom(cardData);
 	}
 }

--- a/backend/src/test/java/kr/codesquad/todo/acceptance/TodoTest.java
+++ b/backend/src/test/java/kr/codesquad/todo/acceptance/TodoTest.java
@@ -1,6 +1,8 @@
 package kr.codesquad.todo.acceptance;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -36,19 +38,29 @@ public class TodoTest {
 		var response = 전체_카드_조회();
 
 		// then
-		Assertions.assertThat(response.statusCode()).isEqualTo(200);
+		assertThat(response.statusCode()).isEqualTo(200);
 	}
 
-	@DisplayName("카테고리별 카드를 조회한다.")
+	@DisplayName("카테고리별 카드 조회를 성공한다.")
 	@Test
-	void retrieveOneCards() {
+	void retrieveOneCards_success() {
 		// when
-		var response1 = 카테고리별_카드_조회(1);
-		var response2 = 카테고리별_카드_조회(100000);
+		var response = 카테고리별_카드_조회(1);
 
 		// then
-		Assertions.assertThat(response1.statusCode()).isEqualTo(HttpStatus.OK.value());
-		Assertions.assertThat(response1.jsonPath().getString("categoryId")).isNotEmpty();
-		Assertions.assertThat(response2.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+		assertAll(
+			() -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+			() -> assertThat(response.jsonPath().getString("categoryId")).isNotEmpty()
+		);
+	}
+
+	@DisplayName("카테고리별 카드 조회를 실패한다.")
+	@Test
+	void retrieveOneCards_fail() {
+		// when
+		var response = 카테고리별_카드_조회(100000);
+
+		// then
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
 	}
 }

--- a/backend/src/test/java/kr/codesquad/todo/acceptance/TodoTest.java
+++ b/backend/src/test/java/kr/codesquad/todo/acceptance/TodoTest.java
@@ -1,0 +1,54 @@
+package kr.codesquad.todo.acceptance;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class TodoTest {
+
+	private static ExtractableResponse<Response> 전체_카드_조회() {
+		return RestAssured
+			.given().log().all()
+			.when().get("/api/cards")
+			.then().log().all()
+			.extract();
+	}
+
+	private static ExtractableResponse<Response> 카테고리별_카드_조회(int categoryId) {
+		return RestAssured
+			.given().log().all().queryParam("categoryId", categoryId)
+			.when().get("/api/cards")
+			.then().log().all()
+			.extract();
+	}
+
+	@DisplayName("전체 카드를 조회한다.")
+	@Test
+	void retrieveAllCards() {
+		// when
+		var response = 전체_카드_조회();
+
+		// then
+		Assertions.assertThat(response.statusCode()).isEqualTo(200);
+	}
+
+	@DisplayName("카테고리별 카드를 조회한다.")
+	@Test
+	void retrieveOneCards() {
+		// when
+		var response1 = 카테고리별_카드_조회(1);
+		var response2 = 카테고리별_카드_조회(100000);
+
+		// then
+		Assertions.assertThat(response1.statusCode()).isEqualTo(HttpStatus.OK.value());
+		Assertions.assertThat(response1.jsonPath().getString("categoryId")).isNotEmpty();
+		Assertions.assertThat(response2.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+	}
+}


### PR DESCRIPTION
## 관련 이슈
- #6 

## 의도 
카드 목록 비즈니스 로직 구현

## 구체적으로 봐야하는 포인트, 세부적인 변경점
- 카드 전체 목록 / 카테고리별 카드 목록을 `card` 테이블에서 조회한다.
- 카드 전체 목록 / 카테고리별 카드 목록을 조회할 때 사용자가 설정한 순서대로 응답한다.
- 카테고리별 카드 목록을 조회할 때 쿼리 파라미터로 들어온 categoryId가 존재하지 않을 경우 404 에러 코드를 응답한다.
- 위의 내용을 확인하기 위해 테스트 코드를 작성했습니다.

This closes #6 