### PR TITLE
[FE] 카드 컴포넌트 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useRef, useState } from "react";
 import styled, { ThemeProvider } from "styled-components";
 import Board from "./components/Board";
 import HistoryBtn from "./components/HistoryBtn";

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -4,6 +4,7 @@ import CloseDanger from "/close-danger.svg";
 import Close from "/close.svg";
 import Edit from "/edit.svg";
 import Plus from "/plus.svg";
+import Card from "./Card";
 
 type data = {
   title: string;
@@ -97,7 +98,9 @@ function Column({
 
           return (
             <li key={index}>
-              <Card {...d} handleDeleteButtonClick={() => handleDeleteButtonClick("선택한 카드를 삭제할까요?", deleteCurrCard)} />
+              <Card
+              {...d} 
+              handleDeleteButtonClick={() => handleDeleteButtonClick("선택한 카드를 삭제할까요?", deleteCurrCard)} />
             </li>
           );
         })}
@@ -186,94 +189,6 @@ const ColumnTitleStyledDiv = styled.div<{ theme: TTheme }>`
       font: ${(props) => props.theme.font.display.medium12};
       color: ${(props) => props.theme.color.text.weak};
       border: 1px solid ${(props) => props.theme.color.border.default};
-    }
-  }
-`;
-
-function Card({ title, text, handleDeleteButtonClick }: { title: string; text: string; handleDeleteButtonClick: () => void }) {
-  return (
-    <CardStyledArticle>
-      <h4 className="blind">카드</h4>
-      <div className="inner">
-        <h4>{title}</h4>
-        <pre>{text}</pre>
-        <p>author by web</p>
-      </div>
-      <ul>
-        <li>
-          <button className="del" onClick={handleDeleteButtonClick}>
-            <img src={Close} alt="삭제" />
-            <img src={CloseDanger} alt="삭제" />
-          </button>
-        </li>
-        <li>
-          <button className="edit">
-            <img src={Edit} alt="수정" />
-          </button>
-        </li>
-      </ul>
-    </CardStyledArticle>
-  );
-}
-
-const CardStyledArticle = styled.article<{ theme: TTheme }>`
-  padding: 16px;
-  border-radius: 8px;
-  background-color: ${(props) => props.theme.color.surface.default};
-  box-shadow: 0px 1px 4px rgba(110, 128, 145, 0.24);
-  display: flex;
-  align-items: flex-start;
-  gap: 16px;
-
-  h4 {
-    font: ${(props) => props.theme.font.display.bold14};
-    color: ${(props) => props.theme.color.text.strong};
-    margin-bottom: 8px;
-  }
-
-  pre {
-    font: ${(props) => props.theme.font.display.medium14};
-    color: ${(props) => props.theme.color.text.default};
-    margin-bottom: 16px;
-  }
-
-  p {
-    font: ${(props) => props.theme.font.display.medium12};
-    color: ${(props) => props.theme.color.text.weak};
-  }
-
-  .inner {
-    flex-grow: 1;
-  }
-
-  ul {
-    flex-shrink: 0;
-    button {
-      display: block;
-      background-color: transparent;
-      border: 0;
-      padding: 0;
-      cursor: pointer;
-      &.del {
-        padding: 5px;
-        img:first-child {
-          display: block;
-        }
-        img:last-child {
-          display: none;
-        }
-        &:hover {
-          img:first-child {
-            display: none;
-          }
-          img:last-child {
-            display: block;
-          }
-        }
-      }
-      &.edit {
-        padding: 4px;
-      }
     }
   }
 `;

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,105 @@
+import { styled } from "styled-components";
+import CloseIcon from "../styles/CloseIcon";
+import EditIcon from "../styles/EditIcon";
+import { TTheme } from "../types/theme";
+
+export default function Card({
+  variant = "default",
+  mode,
+  title,
+  text,
+  handleDeleteButtonClick,
+}: {
+  variant?: "default" | "drag" | "place";
+  mode?: "add" | "edit";
+  title: string;
+  text: string;
+  handleDeleteButtonClick: () => void;
+}) {
+  return (
+    <StyledCard variant={variant}>
+      <h4 className="blind">카드</h4>
+      <div className="inner">
+        <h4>{title}</h4>
+        <pre>{text}</pre>
+        {mode ? (
+          <div>
+            <button>취소</button>
+            <button>{mode === "add" ? "등록" : "저장"}</button>
+          </div>
+        ) : (
+          <p>author by web</p>
+        )}
+      </div>
+      {!mode && (
+        <ul>
+          <li>
+            <button
+              className="del"
+              onClick={() => {
+                handleDeleteButtonClick();
+                console.log("삭제");
+              }}
+            >
+              <CloseIcon />
+            </button>
+          </li>
+          <li>
+            <button
+              className="edit"
+              onClick={() => {
+                console.log("수정");
+              }}
+            >
+              <EditIcon />
+            </button>
+          </li>
+        </ul>
+      )}
+    </StyledCard>
+  );
+}
+
+const StyledCard = styled.article<{ theme: TTheme; variant: "default" | "drag" | "place" }>`
+  width: 300px;
+  padding: 16px;
+  border-radius: 8px;
+  background-color: ${(props) => props.theme.color.surface.default};
+  box-shadow: ${(props) => (props.variant === "drag" ? props.theme.objectStyles.dropShadow.floating : props.theme.objectStyles.dropShadow.normal)};
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  opacity: ${(props) => (props.variant === "place" ? 0.3 : 1)};
+
+  h4 {
+    font: ${(props) => props.theme.font.display.bold14};
+    color: ${(props) => props.theme.color.text.strong};
+    margin-bottom: 8px;
+  }
+
+  pre {
+    font: ${(props) => props.theme.font.display.medium14};
+    color: ${(props) => props.theme.color.text.default};
+    margin-bottom: 16px;
+  }
+
+  p {
+    font: ${(props) => props.theme.font.display.medium12};
+    color: ${(props) => props.theme.color.text.weak};
+  }
+
+  .inner {
+    flex-grow: 1;
+  }
+
+  ul {
+    flex-shrink: 0;
+    button {
+      display: block;
+      background-color: transparent;
+      border: 0;
+      padding: 0;
+      cursor: pointer;
+    }
+  }
+`;

--- a/frontend/src/styles/CloseIcon.tsx
+++ b/frontend/src/styles/CloseIcon.tsx
@@ -1,0 +1,18 @@
+import { styled } from "styled-components";
+
+export default function CloseIcon() {
+  return (
+    <StyledIconWrapper>
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M1.2 12L0 10.8L4.8 6L0 1.2L1.2 0L6 4.8L10.8 0L12 1.2L7.2 6L12 10.8L10.8 12L6 7.2L1.2 12Z" fill="#A0A3BD" />
+      </svg>
+    </StyledIconWrapper>
+  );
+}
+
+const StyledIconWrapper = styled.div`
+  padding: 6px;
+  svg {
+    display: block;
+  }
+`;

--- a/frontend/src/styles/EditIcon.tsx
+++ b/frontend/src/styles/EditIcon.tsx
@@ -1,0 +1,21 @@
+import { styled } from "styled-components";
+
+export default function EditIcon() {
+  return (
+    <StyledIconWrapper>
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M0 11.0837V14H2.91627L11.5173 5.39895L8.60106 2.48268L0 11.0837ZM13.7726 3.1437C13.8447 3.07175 13.9019 2.98629 13.9409 2.89222C13.9799 2.79814 14 2.69729 14 2.59544C14 2.49359 13.9799 2.39274 13.9409 2.29866C13.9019 2.20458 13.8447 2.11912 13.7726 2.04718L11.9528 0.227426C11.8809 0.155333 11.7954 0.0981367 11.7013 0.059112C11.6073 0.0200872 11.5064 0 11.4046 0C11.3027 0 11.2019 0.0200872 11.1078 0.059112C11.0137 0.0981367 10.9282 0.155333 10.8563 0.227426L9.43316 1.65057L12.3494 4.56684L13.7726 3.1437Z"
+          fill="#A0A3BD"
+        />
+      </svg>
+    </StyledIconWrapper>
+  );
+}
+
+const StyledIconWrapper = styled.div`
+  padding: 5px;
+  svg {
+    display: block;
+  }
+`;

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,6 +1,7 @@
 import { TTheme } from "./types/theme";
 
-const fontFamily = '"Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif'
+const fontFamily =
+  '"Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif';
 
 export const theme: TTheme = {
   font: {
@@ -57,8 +58,8 @@ export const theme: TTheme = {
       default: "#6E7191",
       weak: "#A0A3BD",
       white: {
-        default:"#FEFEFE",
-        weak: "#F7F7FC"
+        default: "#FEFEFE",
+        weak: "#F7F7FC",
       },
       brand: "#007AFF",
       danger: "#FF3B30",
@@ -67,10 +68,22 @@ export const theme: TTheme = {
       default: "#FEFEFE",
       alt: "#F7F7FC",
       brand: "#007AFF",
-      danger:"#FF3B30"
+      danger: "#FF3B30",
     },
-    border: {   
-      default: "#EFF0F6"
-    }
+    border: {
+      default: "#EFF0F6",
+    },
+  },
+  objectStyles: {
+    radius: {
+      s: "8px",
+      m: "16px",
+      l: "50%",
+    },
+    dropShadow: {
+      normal: "0px 1px 4px 0px rgba(110, 128, 145, 0.24)",
+      up: "0px 2px 8px 0px rgba(110, 128, 145, 0.16), 0px 2px 8px 0px rgba(110, 128, 145, 0.16)",
+      floating: "0px 16px 16px 0 rgba(110, 128, 145, 0.24), 0px 0px 4px 0px rgba(110, 128, 145, 0.08)",
+    },
   },
 };

--- a/frontend/src/types/theme.ts
+++ b/frontend/src/types/theme.ts
@@ -1,12 +1,11 @@
 // theme.ts
 
-
 export type TTheme = {
   font: {
     bold: {
       L: string;
       M: string;
-      R: string; 
+      R: string;
       S: string;
     };
     medium: {
@@ -61,6 +60,18 @@ export type TTheme = {
     };
     border: {
       default: string;
+    };
+  };
+  objectStyles: {
+    radius: {
+      s: string;
+      m: string;
+      l: string;
+    };
+    dropShadow: {
+      normal: string;
+      up: string;
+      floating: string;
     };
   };
 };


### PR DESCRIPTION
## 관련 이슈
- #20 

## 의도
- 추가, 삭제, 이동 시 디자인을 고려한 카드 컴포넌트 구현

## 구체적으로 봐야하는 포인트, 세부적인 변경점
- 마우스 호버 시 색상 변경을 고려해 CloseIcon, EditIcon 컴포넌트 생성
- theme.ts에 radius, dropShadow 추가
- 기존 카드 컴포넌트를 새로운 카드 컴포넌트로 교체

