### PR TITLE
[BE] 활동기록 등록 AOP

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured:4.5.1'
     runtimeOnly 'com.h2database:h2'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/kr/codesquad/todo/aop/ActionAop.java
+++ b/backend/src/main/java/kr/codesquad/todo/aop/ActionAop.java
@@ -1,0 +1,30 @@
+package kr.codesquad.todo.aop;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import kr.codesquad.todo.dto.request.CardMoveRequest;
+import kr.codesquad.todo.service.ActionService;
+
+@Component
+@Aspect
+public class ActionAop {
+
+	private final ActionService actionService;
+
+	public ActionAop(ActionService actionService) {
+		this.actionService = actionService;
+	}
+
+	@AfterReturning(pointcut = "@annotation(actionLogging)", returning = "id")
+	public void logAction(JoinPoint joinPoint, Long id, ActionLogging actionLogging) {
+		String actionName = actionLogging.value().getDescription();
+		Long originCategoryId = null;
+		if (joinPoint.getArgs().length > 1 && joinPoint.getArgs()[1] instanceof CardMoveRequest) {
+			originCategoryId = ((CardMoveRequest)joinPoint.getArgs()[1]).getToCategoryId();
+		}
+		actionService.create(id, actionName, originCategoryId);
+	}
+}

--- a/backend/src/main/java/kr/codesquad/todo/aop/ActionAop.java
+++ b/backend/src/main/java/kr/codesquad/todo/aop/ActionAop.java
@@ -20,11 +20,10 @@ public class ActionAop {
 
 	@AfterReturning(pointcut = "@annotation(actionLogging)", returning = "id")
 	public void logAction(JoinPoint joinPoint, Long id, ActionLogging actionLogging) {
-		String actionName = actionLogging.value().getDescription();
 		Long originCategoryId = null;
 		if (joinPoint.getArgs().length > 1 && joinPoint.getArgs()[1] instanceof CardMoveRequest) {
 			originCategoryId = ((CardMoveRequest)joinPoint.getArgs()[1]).getToCategoryId();
 		}
-		actionService.create(id, actionName, originCategoryId);
+		actionService.create(id, actionLogging.value(), originCategoryId);
 	}
 }

--- a/backend/src/main/java/kr/codesquad/todo/aop/ActionLogging.java
+++ b/backend/src/main/java/kr/codesquad/todo/aop/ActionLogging.java
@@ -1,0 +1,15 @@
+package kr.codesquad.todo.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import kr.codesquad.todo.domain.ActionType;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ActionLogging {
+
+	ActionType value();
+}

--- a/backend/src/main/java/kr/codesquad/todo/domain/ActionType.java
+++ b/backend/src/main/java/kr/codesquad/todo/domain/ActionType.java
@@ -1,5 +1,7 @@
 package kr.codesquad.todo.domain;
 
+import java.time.LocalDateTime;
+
 public enum ActionType {
 
 	REGISTER("등록"),
@@ -11,6 +13,11 @@ public enum ActionType {
 
 	ActionType(String description) {
 		this.description = description;
+	}
+
+	public Action from(String cardName, String originCategoryName, String targetCategoryName, Long userId) {
+		return new Action(null, description, cardName, originCategoryName, targetCategoryName, LocalDateTime.now(),
+			userId);
 	}
 
 	public String getDescription() {

--- a/backend/src/main/java/kr/codesquad/todo/dto/response/CardDataForActionResponse.java
+++ b/backend/src/main/java/kr/codesquad/todo/dto/response/CardDataForActionResponse.java
@@ -1,0 +1,26 @@
+package kr.codesquad.todo.dto.response;
+
+public class CardDataForActionResponse {
+
+	private final String cardName;
+	private final String targetCategoryName;
+	private final Long userId;
+
+	public CardDataForActionResponse(String cardName, String targetCategoryName, Long userId) {
+		this.cardName = cardName;
+		this.targetCategoryName = targetCategoryName;
+		this.userId = userId;
+	}
+
+	public String getCardName() {
+		return cardName;
+	}
+
+	public String getTargetCategoryName() {
+		return targetCategoryName;
+	}
+
+	public Long getUserId() {
+		return userId;
+	}
+}

--- a/backend/src/main/java/kr/codesquad/todo/dto/response/CardsResponse.java
+++ b/backend/src/main/java/kr/codesquad/todo/dto/response/CardsResponse.java
@@ -8,6 +8,9 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import kr.codesquad.todo.exeption.BusinessException;
+import kr.codesquad.todo.exeption.ErrorCode;
+
 public class CardsResponse {
 
 	private final Long categoryId;
@@ -40,7 +43,7 @@ public class CardsResponse {
 		return card.entrySet().stream()
 			.map(CardsResponse::from)
 			.findFirst()
-			.orElse(new CardsResponse());
+			.orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
 	}
 
 	private static CardsResponse from(Map.Entry<CategoryResponse, List<CardData>> entry) {

--- a/backend/src/main/java/kr/codesquad/todo/dto/response/CardsResponse.java
+++ b/backend/src/main/java/kr/codesquad/todo/dto/response/CardsResponse.java
@@ -6,14 +6,19 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import kr.codesquad.todo.exeption.BusinessException;
-import kr.codesquad.todo.exeption.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class CardsResponse {
 
 	private final Long categoryId;
 	private final String categoryName;
 	private final List<CardData> cards;
+
+	public CardsResponse() {
+		this.categoryId = null;
+		this.categoryName = null;
+		this.cards = null;
+	}
 
 	public CardsResponse(Long categoryId, String categoryName, List<CardData> cards) {
 		this.categoryId = categoryId;
@@ -35,7 +40,7 @@ public class CardsResponse {
 		return card.entrySet().stream()
 			.map(CardsResponse::from)
 			.findFirst()
-			.orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+			.orElse(new CardsResponse());
 	}
 
 	private static CardsResponse from(Map.Entry<CategoryResponse, List<CardData>> entry) {
@@ -61,14 +66,17 @@ public class CardsResponse {
 		return answer;
 	}
 
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public Long getCategoryId() {
 		return categoryId;
 	}
 
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public String getCategoryName() {
 		return categoryName;
 	}
 
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public List<CardData> getCards() {
 		return cards;
 	}

--- a/backend/src/main/java/kr/codesquad/todo/repository/CardRepository.java
+++ b/backend/src/main/java/kr/codesquad/todo/repository/CardRepository.java
@@ -24,13 +24,19 @@ import kr.codesquad.todo.dto.response.CategoryResponse;
 @Repository
 public class CardRepository {
 
-	private static final RowMapper<CardData> cardDataRowMapper = ((rs, rowNum) -> new CardData(
+	private static final RowMapper<CardData> CARD_DATA_ROW_MAPPER = ((rs, rowNum) -> new CardData(
 		rs.getLong("id"),
 		rs.getString("title"),
 		rs.getString("content"),
 		rs.getString("nickname"),
 		rs.getLong("prev_card_id"),
 		new CategoryResponse(rs.getLong("category_id"), rs.getString("name"))));
+	private static final RowMapper<CardDataForActionResponse> CARD_DATA_FOR_ACTION_RESPONSE_ROW_MAPPER = (rs, rowNum) ->
+		new CardDataForActionResponse(
+			rs.getString("title"),
+			rs.getString("name"),
+			rs.getLong("user_account_id")
+		);
 	private final NamedParameterJdbcTemplate jdbcTemplate;
 	private final SimpleJdbcInsert simpleJdbcInsert;
 
@@ -117,7 +123,7 @@ public class CardRepository {
 				+ "RIGHT JOIN category cg ON c.category_id = cg.id AND c.is_deleted = false "
 				+ "LEFT JOIN user_account u ON cg.user_account_id = u.id "
 				+ "WHERE u.id = 1";
-		return jdbcTemplate.query(findAll, cardDataRowMapper);
+		return jdbcTemplate.query(findAll, CARD_DATA_ROW_MAPPER);
 	}
 
 	public List<CardData> findByCategoryId(Long categoryId) {
@@ -126,7 +132,7 @@ public class CardRepository {
 				+ "RIGHT JOIN category cg ON c.category_id = cg.id AND c.is_deleted = false"
 				+ "LEFT JOIN user_account u ON cg.user_account_id = u.id "
 				+ "WHERE u.id = 1 AND cg.id = :categoryId";
-		return jdbcTemplate.query(findByCategoryId, Map.of("categoryId", categoryId), cardDataRowMapper);
+		return jdbcTemplate.query(findByCategoryId, Map.of("categoryId", categoryId), CARD_DATA_ROW_MAPPER);
 	}
 
 	public void deleteAllByCategoryId(Long categoryId) {
@@ -140,14 +146,7 @@ public class CardRepository {
 			+ "WHERE c.id = :id";
 		return Optional.ofNullable(
 			DataAccessUtils.singleResult(
-				jdbcTemplate.query(cardDataForActionResponse, Map.of("id", cardId), (rs, rowNum) ->
-					new CardDataForActionResponse(
-						rs.getString("title"),
-						rs.getString("name"),
-						rs.getLong("user_account_id")
-					)
-				)
-			)
-		);
+				jdbcTemplate.query(cardDataForActionResponse, Map.of("id", cardId),
+					CARD_DATA_FOR_ACTION_RESPONSE_ROW_MAPPER)));
 	}
 }

--- a/backend/src/main/java/kr/codesquad/todo/service/ActionService.java
+++ b/backend/src/main/java/kr/codesquad/todo/service/ActionService.java
@@ -1,12 +1,12 @@
 package kr.codesquad.todo.service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.codesquad.todo.domain.Action;
+import kr.codesquad.todo.domain.ActionType;
 import kr.codesquad.todo.dto.response.ActionResponse;
 import kr.codesquad.todo.dto.response.CardDataForActionResponse;
 import kr.codesquad.todo.dto.response.Slice;
@@ -52,17 +52,16 @@ public class ActionService {
 	}
 
 	@Transactional
-	public void create(Long id, String actionName, Long originCategoryId) {
-		CardDataForActionResponse cardDataForActionResponse = cardRepository.findCardDataById(id)
+	public void create(Long cardId, ActionType actionType, Long originCategoryId) {
+		CardDataForActionResponse cardDataForActionResponse = cardRepository.findCardDataById(cardId)
 			.orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
 		String originCategoryName = null;
 		if (originCategoryId != null) {
 			originCategoryName = categoryRepository.findNameById(originCategoryId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
 		}
-		Action action = new Action(null, actionName, cardDataForActionResponse.getCardName(), originCategoryName,
-			cardDataForActionResponse.getTargetCategoryName(), LocalDateTime.now(),
-			cardDataForActionResponse.getUserId());
+		Action action = actionType.from(cardDataForActionResponse.getCardName(), originCategoryName,
+			cardDataForActionResponse.getTargetCategoryName(), cardDataForActionResponse.getUserId());
 		actionRepository.save(action);
 	}
 

--- a/backend/src/main/java/kr/codesquad/todo/service/ActionService.java
+++ b/backend/src/main/java/kr/codesquad/todo/service/ActionService.java
@@ -1,27 +1,33 @@
 package kr.codesquad.todo.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.codesquad.todo.domain.Action;
-import kr.codesquad.todo.domain.ActionType;
-import kr.codesquad.todo.dto.ActionData;
 import kr.codesquad.todo.dto.response.ActionResponse;
+import kr.codesquad.todo.dto.response.CardDataForActionResponse;
 import kr.codesquad.todo.dto.response.Slice;
+import kr.codesquad.todo.exeption.BusinessException;
+import kr.codesquad.todo.exeption.ErrorCode;
 import kr.codesquad.todo.repository.ActionRepository;
+import kr.codesquad.todo.repository.CardRepository;
+import kr.codesquad.todo.repository.CategoryRepository;
 
 @Service
 public class ActionService {
 
 	private final ActionRepository actionRepository;
+	private final CardRepository cardRepository;
+	private final CategoryRepository categoryRepository;
 
-	public ActionService(ActionRepository actionRepository) {
+	public ActionService(ActionRepository actionRepository, CardRepository cardRepository,
+		CategoryRepository categoryRepository) {
 		this.actionRepository = actionRepository;
-	}
-
-	@Transactional
-	public void register(ActionType actionType, ActionData actionData) {
-		actionRepository.save(actionData.toResponse(actionType).toEntity());
+		this.cardRepository = cardRepository;
+		this.categoryRepository = categoryRepository;
 	}
 
 	// 활동기록(히스토리) 목록 조회
@@ -43,5 +49,25 @@ public class ActionService {
 		// 로그인된 유저 정보를 이용해서 본인의 활동기록만 삭제할 수 있도록 해야한다.
 
 		actionRepository.deleteAll();
+	}
+
+	@Transactional
+	public void create(Long id, String actionName, Long originCategoryId) {
+		CardDataForActionResponse cardDataForActionResponse = cardRepository.findCardDataById(id)
+			.orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
+		String originCategoryName = null;
+		if (originCategoryId != null) {
+			originCategoryName = categoryRepository.findNameById(originCategoryId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+		}
+		Action action = new Action(null, actionName, cardDataForActionResponse.getCardName(), originCategoryName,
+			cardDataForActionResponse.getTargetCategoryName(), LocalDateTime.now(),
+			cardDataForActionResponse.getUserId());
+		actionRepository.save(action);
+	}
+
+	@Transactional(readOnly = true)
+	public List<ActionResponse> retrieveAll(Long userId) {
+		return actionRepository.retrieveAll(userId);
 	}
 }

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -12,6 +12,7 @@ CREATE TABLE card
     modified_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP(0) ON UPDATE CURRENT_TIMESTAMP(0),
     category_id  BIGINT       NOT NULL,
     prev_card_id BIGINT       NOT NULL,
+    is_deleted   BOOLEAN      NOT NULL DEFAULT FALSE,
     PRIMARY KEY (`id`)
 );
 

--- a/backend/src/test/java/kr/codesquad/todo/aop/ActionAopTest.java
+++ b/backend/src/test/java/kr/codesquad/todo/aop/ActionAopTest.java
@@ -1,0 +1,143 @@
+package kr.codesquad.todo.aop;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import kr.codesquad.todo.acceptance.DatabaseAccessor;
+import kr.codesquad.todo.acceptance.DatabaseInitializer;
+import kr.codesquad.todo.domain.ActionType;
+import kr.codesquad.todo.dto.response.ActionResponse;
+import kr.codesquad.todo.fixture.FixtureFactory;
+import kr.codesquad.todo.service.ActionService;
+import kr.codesquad.todo.service.CardService;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+class ActionAopTest {
+
+	@Autowired
+	DatabaseInitializer databaseInitializer;
+	@Autowired
+	DatabaseAccessor databaseAccessor;
+	@Autowired
+	private CardService cardService;
+	@Autowired
+	private ActionService actionService;
+
+	@BeforeEach
+	void setUp() {
+		databaseInitializer.truncateTables();
+		databaseInitializer.initTables();
+	}
+
+	@DisplayName("통합테스트")
+	@Test
+	void AopTest() {
+		// given
+		Long userId = 1L;
+		Long categoryId = 1L;
+		Long cardId = 1L;
+		Long fromPrevId = 0L;
+		Long toCategoryId = 1L;
+		Long toPrevId = 3L;
+
+		// when
+		cardService.register(categoryId, FixtureFactory.createCardCreationRequest());
+		cardService.update(cardId, FixtureFactory.updateCardCreationRequest());
+		cardService.move(cardId, FixtureFactory.createCardMoveRequest(fromPrevId, toCategoryId, toPrevId));
+		cardService.delete(cardId);
+		List<ActionResponse> actions = actionService.retrieveAll(userId);
+
+		// then
+		assertAll(
+			() -> assertThat(actions.size()).isEqualTo(4),
+			() -> assertThat(actions.get(0).getActionName()).isEqualTo(ActionType.REGISTER.getDescription()),
+			() -> assertThat(actions.get(1).getActionName()).isEqualTo(ActionType.MODIFY.getDescription()),
+			() -> assertThat(actions.get(2).getActionName()).isEqualTo(ActionType.MOVE.getDescription()),
+			() -> assertThat(actions.get(3).getActionName()).isEqualTo(ActionType.DELETE.getDescription())
+		);
+	}
+
+	@DisplayName("카드 등록 후 액션 저장에 성공한다.")
+	@Test
+	void registerAopTest() {
+		// given
+		Long userId = 1L;
+		Long categoryId = 1L;
+
+		// when
+		cardService.register(categoryId, FixtureFactory.createCardCreationRequest());
+		cardService.register(categoryId, FixtureFactory.createCardCreationRequest());
+		List<ActionResponse> actions = actionService.retrieveAll(userId);
+
+		// then
+		assertAll(
+			() -> assertThat(actions.size()).isEqualTo(2),
+			() -> assertThat(actions.get(0).getActionName()).isEqualTo(ActionType.REGISTER.getDescription())
+		);
+	}
+
+	@DisplayName("카드 수정 후 액션 저장에 성공한다.")
+	@Test
+	void updateAopTest() {
+		// given
+		Long userId = 1L;
+		Long cardId = 1L;
+
+		// when
+		cardService.update(cardId, FixtureFactory.updateCardCreationRequest());
+		List<ActionResponse> actions = actionService.retrieveAll(userId);
+
+		// then
+		assertAll(
+			() -> assertThat(actions.size()).isEqualTo(1),
+			() -> assertThat(actions.get(0).getActionName()).isEqualTo(ActionType.MODIFY.getDescription())
+		);
+	}
+
+	@DisplayName("카드 이동 후 액션 저장에 성공한다.")
+	@Test
+	void moveAopTest() {
+		// given
+		Long userId = 1L;
+		Long cardId = 1L;
+		Long fromPrevId = 0L;
+		Long toCategoryId = 1L;
+		Long toPrevId = 3L;
+
+		// when
+		cardService.move(cardId, FixtureFactory.createCardMoveRequest(fromPrevId, toCategoryId, toPrevId));
+		List<ActionResponse> actions = actionService.retrieveAll(userId);
+
+		// then
+		assertAll(
+			() -> assertThat(actions.size()).isEqualTo(1),
+			() -> assertThat(actions.get(0).getActionName()).isEqualTo(ActionType.MOVE.getDescription())
+		);
+	}
+
+	@DisplayName("카드 삭제 후 액션 저장에 성공한다.")
+	@Test
+	void deleteAopTest() {
+		// given
+		Long userId = 1L;
+		Long cardId = 1L;
+
+		// when
+		cardService.delete(cardId);
+		List<ActionResponse> actions = actionService.retrieveAll(userId);
+
+		// then
+		assertAll(
+			() -> assertThat(actions.size()).isEqualTo(1),
+			() -> assertThat(actions.get(0).getActionName()).isEqualTo(ActionType.DELETE.getDescription())
+		);
+	}
+}

--- a/backend/src/test/java/kr/codesquad/todo/fixture/FixtureFactory.java
+++ b/backend/src/test/java/kr/codesquad/todo/fixture/FixtureFactory.java
@@ -12,6 +12,10 @@ public class FixtureFactory {
 		return new CardCreationRequest("Github 공부하기", "열심히 해야지~");
 	}
 
+	public static CardCreationRequest updateCardCreationRequest() {
+		return new CardCreationRequest("수정된 제목", "수정된 내용");
+	}
+
 	public static CategoryRequest createCategoryRequest() {
 		return new CategoryRequest("1일 1커밋 도전!");
 	}

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -12,6 +12,7 @@ CREATE TABLE card
     modified_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP(0) ON UPDATE CURRENT_TIMESTAMP(0),
     category_id  BIGINT       NOT NULL,
     prev_card_id BIGINT       NOT NULL,
+    is_deleted   BOOLEAN      NOT NULL DEFAULT FALSE,
     PRIMARY KEY (`id`)
 );
 


### PR DESCRIPTION
## 관련 이슈
- #23 

## 의도 
사용자의 활동 기록 등록을 AOP를 사용하여 구현한 것을 기록하기 위해서 풀리퀘 작성

## 구체적으로 봐야하는 포인트, 세부적인 변경점
- `card` 테이블에 is_deleted 칼럼 추가로 soft delete로 변경했습니다. -> 카드 관련 sql에 `is_deleted = false` 추가했습니다. 카드 조회 부분은 where절 말고 join할 때 on에 조건을 추가해주어야지 원하던대로 null값도 나오게 됩니다.
- 사용자의 활동 기록(등록, 변경, 이동, 삭제)을 action 테이블에 저장했습니다.
- 카드 이동 시에만 `originCategoryName` 정보를 저장하고 나머지 활동은 null값을 저장합니다.
- 위의 내용을 확인하기 위해 테스트 코드를 작성했습니다.