### PR TITLE
[FE] 카드 이동 기능 구현

### DIFF
--- a/frontend/src/components/main/board/Board.tsx
+++ b/frontend/src/components/main/board/Board.tsx
@@ -1,13 +1,38 @@
-import { useEffect, useState } from "react";
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { createContext, useEffect, useState } from "react";
 import { styled } from "styled-components";
+import TCard from "../../../types/TCard";
 import TColumn from "../../../types/TColumn";
 import TTheme from "../../../types/TTheme";
 import fetchData from "../../../utils/fetch";
 import Column from "./column/Column";
 
+export const DragContext = createContext({
+  draggingCardData: {} as TCard | undefined,
+  handleDraggingCardDataUpdate: (cardData: TCard) => {},
+  draggingCardPosition: undefined as { x: number; y: number } | undefined,
+  handleDraggingCardPositionUpdate: (position: { x: number; y: number }) => {},
+  isDragging: false,
+  startDragging: () => {},
+  allCardRects: [] as { id: number; rect: DOMRect }[],
+  addCardRect: (id: number, rect: DOMRect) => {},
+  draggingDestinationData: { categoryId: 0, index: -1, isBefore: false } as { categoryId: number; index: number; isBefore: boolean },
+  addColumnRect: (id: number, rect: DOMRect) => {},
+});
+
 const Board = styled(({ className }: { className?: string }) => {
   const [columns, setColumns] = useState<TColumn[]>([]);
   const [activeCardFormIdentifier, setActiveCardFormIdentifier] = useState<{ cardId: number; categoryId: number }>({ cardId: 0, categoryId: 0 });
+  const [draggingCardData, setDraggingCardData] = useState<TCard | undefined>();
+  const [draggingCardPosition, setDraggingCardPosition] = useState<{ x: number; y: number } | undefined>();
+  const [draggingDestinationData, setDraggingDestinationData] = useState<{ categoryId: number; index: number; isBefore: boolean }>({
+    categoryId: 0,
+    index: -1,
+    isBefore: false,
+  });
+  const [isDragging, setIsDragging] = useState(false);
+  const [allCardRects, setAllCardRects] = useState<{ id: number; rect: DOMRect }[]>([]);
+  const [allColumnRects, setAllColumnRects] = useState<{ id: number; rect: DOMRect }[]>([]);
 
   useEffect(() => {
     updateColumns();
@@ -40,16 +65,90 @@ const Board = styled(({ className }: { className?: string }) => {
     setActiveCardFormIdentifier({ cardId: 0, categoryId: 0 });
   };
 
+  const handleDraggingCardDataUpdate = (cardData: TCard) => {
+    setDraggingCardData(cardData);
+  };
+
+  const handleDraggingCardPositionUpdate = (position: { x: number; y: number }) => {
+    for (const cardRect of allCardRects) {
+      if (
+        cardRect.rect.left < position.x &&
+        cardRect.rect.right > position.x &&
+        cardRect.rect.top < position.y &&
+        cardRect.rect.bottom > position.y
+      ) {
+        const middleOfHeight = cardRect.rect.top + cardRect.rect.height / 2;
+        const isBefore = position.y <= middleOfHeight;
+        const column = columns.find((column) => column.cards.some((card) => card.id === cardRect.id));
+        const index = column?.cards.findIndex((card) => card.id === cardRect.id) ?? 0;
+
+        setDraggingDestinationData({ categoryId: column?.categoryId ?? 0, index, isBefore });
+        return;
+      }
+    }
+
+    for (const columnRect of allColumnRects) {
+      if (
+        columnRect.rect.left < position.x &&
+        columnRect.rect.right > position.x &&
+        columnRect.rect.top < position.y &&
+        columnRect.rect.bottom > position.y
+      ) {
+        setDraggingDestinationData({ categoryId: columnRect.id, index: -1, isBefore: false });
+        return;
+      }
+    }
+  };
+
+  const startDragging = () => {
+    setIsDragging(true);
+  };
+
+  const addCardRect = (id: number, rect: DOMRect) => {
+    setAllCardRects((c) => {
+      const index = c.findIndex((cardRect) => cardRect.id === id);
+      if (index === -1) {
+        return [...c, { id, rect }];
+      }
+      return c;
+    });
+  };
+
+  const addColumnRect = (id: number, rect: DOMRect) => {
+    setAllColumnRects((c) => {
+      const index = c.findIndex((columnRect) => columnRect.id === id);
+      if (index === -1) {
+        return [...c, { id, rect }];
+      }
+      return c;
+    });
+  };
+
   return (
-    <ul className={className}>
-      {columns.map((column) => {
-        return (
-          <li key={column.categoryId}>
-            <Column {...{ ...column, onCardChanged: updateColumns, activeCardFormIdentifier, toggleAddForm, openEditForm, closeCardForm }} />
-          </li>
-        );
-      })}
-    </ul>
+    <DragContext.Provider
+      value={{
+        draggingCardData,
+        handleDraggingCardDataUpdate,
+        draggingCardPosition,
+        handleDraggingCardPositionUpdate,
+        isDragging,
+        startDragging,
+        allCardRects,
+        addCardRect,
+        draggingDestinationData,
+        addColumnRect,
+      }}
+    >
+      <ul className={className}>
+        {columns.map((column) => {
+          return (
+            <li key={column.categoryId}>
+              <Column {...{ ...column, onCardChanged: updateColumns, activeCardFormIdentifier, toggleAddForm, openEditForm, closeCardForm }} />
+            </li>
+          );
+        })}
+      </ul>
+    </DragContext.Provider>
   );
 })<{ theme: TTheme }>`
   display: flex;

--- a/frontend/src/components/main/board/Board.tsx
+++ b/frontend/src/components/main/board/Board.tsx
@@ -18,6 +18,14 @@ export const DragContext = createContext({
   addCardRect: (id: number, rect: DOMRect) => {},
   draggingDestinationData: { categoryId: 0, index: -1, isBefore: false } as { categoryId: number; index: number; isBefore: boolean },
   addColumnRect: (id: number, rect: DOMRect) => {},
+  getDropData: () => {
+    return {
+      fromPrevCardId: 0,
+      toCategoryId: 0,
+      toPrevCardId: 0,
+    };
+  },
+  initializeDragStates: () => {},
 });
 
 const Board = styled(({ className }: { className?: string }) => {
@@ -124,6 +132,34 @@ const Board = styled(({ className }: { className?: string }) => {
     });
   };
 
+  const getDropData = () => {
+    if (!isDragging || !draggingCardData || !draggingDestinationData) {
+      return {
+        fromPrevCardId: 0,
+        toCategoryId: 0,
+        toPrevCardId: 0,
+      };
+    }
+
+    const { categoryId, index, isBefore } = draggingDestinationData;
+    const { id: cardId } = draggingCardData;
+
+    const fromPrevCardId = columns.find((column) => column.cards.some((card) => card.id === cardId))?.cards[index - 1]?.id ?? 0;
+    const toPrevCardId = isBefore
+      ? columns.find((column) => column.categoryId === categoryId)?.cards[index - 1]?.id ?? 0
+      : columns.find((column) => column.categoryId === categoryId)?.cards[index]?.id ?? 0;
+
+    return {
+      fromPrevCardId,
+      toCategoryId: categoryId,
+      toPrevCardId,
+    };
+  };
+
+  const initializeDragStates = () => {
+    setIsDragging(false);
+  };
+
   return (
     <DragContext.Provider
       value={{
@@ -137,6 +173,8 @@ const Board = styled(({ className }: { className?: string }) => {
         addCardRect,
         draggingDestinationData,
         addColumnRect,
+        getDropData,
+        initializeDragStates,
       }}
     >
       <ul className={className}>

--- a/frontend/src/components/main/board/column/Column.tsx
+++ b/frontend/src/components/main/board/column/Column.tsx
@@ -1,10 +1,13 @@
+import { useContext, useEffect, useRef } from "react";
 import { styled } from "styled-components";
 import TCard from "../../../../types/TCard";
 import TTheme from "../../../../types/TTheme";
 import fetchData from "../../../../utils/fetch";
+import { DragContext } from "../Board";
 import ColumnTitle from "./ColumnTitle";
 import Card from "./card/Card";
 import CardForm from "./card/CardForm";
+import CardShadow from "./card/CardShadow";
 
 const Column = styled(
   ({
@@ -28,6 +31,15 @@ const Column = styled(
     closeCardForm: () => void;
     onCardChanged: () => Promise<void>;
   }) => {
+    const componentRef = useRef<HTMLElement>(null);
+    const { draggingCardData, isDragging, draggingDestinationData, addColumnRect } = useContext(DragContext);
+
+    useEffect(() => {
+      if (componentRef.current) {
+        addColumnRect(categoryId, componentRef.current.getBoundingClientRect());
+      }
+    }, []);
+
     const addCard = async ({ title, content }: { title: string; content: string }) => {
       await fetchData(
         `/api/cards?categoryId=${categoryId}`,
@@ -86,8 +98,10 @@ const Column = styled(
       return cardId === activeCardFormIdentifier.cardId && categoryId === activeCardFormIdentifier.categoryId;
     };
 
+    console.log("draggingDestinationData", draggingDestinationData.index);
+
     return (
-      <article className={className}>
+      <article className={className} ref={componentRef}>
         <ColumnTitle title={categoryName} count={cards.length} handlePlusButtonClick={() => toggleAddForm(categoryId)} />
         <ul className="card-list">
           {isActiveAddForm && (
@@ -95,23 +109,53 @@ const Column = styled(
               <CardForm mode="add" handleCancelButtonClick={closeCardForm} handleSubmitButtonClick={addCard} />
             </li>
           )}
-          {cards.map((card) => (
-            <li key={card.id}>
-              {isActiveEditForm(card.id) ? (
-                <CardForm mode="edit" originalContent={card} handleCancelButtonClick={closeCardForm} handleSubmitButtonClick={editCard} />
-              ) : (
-                <Card {...card} onDelete={() => deleteCard(card.id)} onEdit={() => openEditForm(card.id, categoryId)} />
-              )}
-            </li>
+          {cards.map((card, index, cards) => (
+            <>
+              {isDragging &&
+                draggingCardData &&
+                draggingDestinationData.categoryId === categoryId &&
+                draggingDestinationData.index === index &&
+                draggingDestinationData.isBefore && (
+                  <li>
+                    <CardShadow {...draggingCardData} />
+                  </li>
+                )}
+              <li key={card.id}>
+                {isActiveEditForm(card.id) ? (
+                  <CardForm mode="edit" originalContent={card} handleCancelButtonClick={closeCardForm} handleSubmitButtonClick={editCard} />
+                ) : (
+                  <Card {...card} onDelete={() => deleteCard(card.id)} onEdit={() => openEditForm(card.id, categoryId)} />
+                )}
+              </li>
+              {isDragging &&
+                draggingCardData &&
+                draggingDestinationData.categoryId === categoryId &&
+                draggingDestinationData.index === index &&
+                cards.length - 1 === index &&
+                !draggingDestinationData.isBefore && (
+                  <li>
+                    <CardShadow {...draggingCardData} />
+                  </li>
+                )}
+            </>
           ))}
+          {isDragging && draggingCardData && draggingDestinationData.categoryId === categoryId && draggingDestinationData.index === -1 && (
+            <li>
+              <CardShadow {...draggingCardData} />
+            </li>
+          )}
         </ul>
       </article>
     );
   }
 )<{ theme: TTheme }>`
   min-width: 300px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 
   .card-list {
+    height: 100%;
     display: flex;
     flex-direction: column;
     gap: 10px;

--- a/frontend/src/components/main/board/column/Column.tsx
+++ b/frontend/src/components/main/board/column/Column.tsx
@@ -98,8 +98,6 @@ const Column = styled(
       return cardId === activeCardFormIdentifier.cardId && categoryId === activeCardFormIdentifier.categoryId;
     };
 
-    console.log("draggingDestinationData", draggingDestinationData.index);
-
     return (
       <article className={className} ref={componentRef}>
         <ColumnTitle title={categoryName} count={cards.length} handlePlusButtonClick={() => toggleAddForm(categoryId)} />
@@ -124,7 +122,7 @@ const Column = styled(
                 {isActiveEditForm(card.id) ? (
                   <CardForm mode="edit" originalContent={card} handleCancelButtonClick={closeCardForm} handleSubmitButtonClick={editCard} />
                 ) : (
-                  <Card {...card} onDelete={() => deleteCard(card.id)} onEdit={() => openEditForm(card.id, categoryId)} />
+                  <Card {...card} onDelete={() => deleteCard(card.id)} onEdit={() => openEditForm(card.id, categoryId)} onCardChanged={onCardChanged} />
                 )}
               </li>
               {isDragging &&

--- a/frontend/src/components/main/board/column/card/Card.tsx
+++ b/frontend/src/components/main/board/column/card/Card.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState, useCallback } from "react";
 import { css, styled } from "styled-components";
 import { useAlert } from "../../../../../hooks/useAlert";
 import TTheme from "../../../../../types/TTheme";
@@ -7,16 +7,69 @@ import Buttons from "../../../../common/Buttons";
 type TMode = "Default" | "Add/Edit" | "Drag" | "Place";
 
 const Card = styled(
-  ({ className, title, content, onDelete, onEdit }: { className?: string; title: string; content: string; onDelete: () => Promise<void>, onEdit: () => void }) => {
+  ({
+    className,
+    title,
+    content,
+    onDelete,
+    onEdit,
+  }: {
+    className?: string;
+    title: string;
+    content: string;
+    onDelete: () => Promise<void>;
+    onEdit: () => void;
+  }) => {
     const [mode, setMode] = useState<TMode>("Default");
+    const [isMouseDown, setIsMouseDown] = useState(false);
+    const [dragOffset, setDragOffset] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+    const [position, setPosition] = useState<{ x: number; y: number }>();
 
     function editFormSubmitHandler(event: FormEvent<HTMLFormElement>): void {
       event.preventDefault();
       console.log(event.target);
     }
 
+    const handleMouseDown = (e: React.MouseEvent) => {
+      const cardRect = e.currentTarget.getBoundingClientRect();
+      const offsetX = e.clientX - cardRect.left;
+      const offsetY = e.clientY - cardRect.top;
+      setDragOffset({ x: offsetX, y: offsetY });
+      setIsMouseDown(true);
+    };
+
+    const handleMouseMove = useCallback((e: MouseEvent) => {
+      setPosition({
+        x: e.clientX - dragOffset.x,
+        y: e.clientY - dragOffset.y,
+      });
+    }, [dragOffset]);
+
+    const handleMouseUp = () => {
+      setIsMouseDown(false);
+    };
+
+    const positionStyle: React.CSSProperties = position
+      ? {
+          position: "absolute",
+          left: `${position.x}px`,
+          top: `${position.y}px`,
+        }
+      : {};
+
+    useEffect(() => {
+      if (!isMouseDown) {
+        return;
+      }
+      window.addEventListener("mousemove", handleMouseMove);
+
+      return () => {
+        window.removeEventListener("mousemove", handleMouseMove);
+      };
+    }, [isMouseDown, handleMouseMove]);
+
     return (
-      <article className={className} data-mode={mode}>
+      <article className={className} data-mode={mode} onMouseDown={handleMouseDown} onMouseUp={handleMouseUp} style={positionStyle}>
         <h4 className="blind">카드</h4>
         {mode !== "Add/Edit" && (
           <div className="container">
@@ -75,6 +128,7 @@ const Card = styled(
   ${({ theme }) => {
     const { color, font } = theme;
     return css`
+      width: 300px;
       padding: 16px;
       border-radius: 8px;
       background-color: ${color.surface.default};

--- a/frontend/src/components/main/board/column/card/CardShadow.tsx
+++ b/frontend/src/components/main/board/column/card/CardShadow.tsx
@@ -1,0 +1,117 @@
+import { css, styled } from "styled-components";
+import TTheme from "../../../../../types/TTheme";
+import Buttons from "../../../../common/Buttons";
+
+const CardShadow = styled(
+  ({ className, id, title, content, nickname }: { className?: string; id: number; title: string; content: string; nickname: string }) => {
+    const mode = "Place";
+
+    return (
+      <article className={className} data-mode={mode}>
+        <h4 className="blind">카드</h4>
+        <div className="container">
+          <div className="inner">
+            <h4>{title}</h4>
+            <pre>{content}</pre>
+            <p>author by web</p>
+          </div>
+          <menu className="control">
+            <li>
+              <Buttons $Flexible="" $Type="Ghost" $ElementPattern="Icon Only" $States="Enable" icon="Close" />
+            </li>
+            <li>
+              <Buttons $Flexible="" $Type="Ghost" $ElementPattern="Icon Only" $States="Enable" icon="Edit" />
+            </li>
+          </menu>
+        </div>
+      </article>
+    );
+  }
+)<{ theme: TTheme }>`
+  ${({ theme }) => {
+    const { color, font } = theme;
+    return css`
+      width: 300px;
+      padding: 16px;
+      border-radius: 8px;
+      background-color: ${color.surface.default};
+      box-shadow: 0px 1px 4px rgba(110, 128, 145, 0.24);
+      opacity: 0.3;
+
+      & > .container {
+        display: flex;
+        align-items: flex-start;
+        gap: 16px;
+      }
+
+      h4 {
+        font: ${font.display.bold14};
+        color: ${color.text.strong};
+        margin-bottom: 8px;
+      }
+
+      pre {
+        font: ${font.display.medium14};
+        color: ${color.text.default};
+      }
+
+      p {
+        font: ${font.display.medium12};
+        margin-top: 16px;
+        color: ${color.text.weak};
+      }
+
+      form {
+        input {
+          background: transparent;
+          border: 0;
+          margin-top: -1px;
+          margin-left: -2px;
+        }
+        input[name="title"] {
+          font: ${font.display.bold14};
+          color: ${color.text.strong};
+          margin-bottom: 7px;
+        }
+        textarea[name="body"] {
+          font: ${font.display.medium14};
+          color: ${color.text.default};
+          margin-bottom: 6px;
+        }
+      }
+
+      .inner {
+        flex-grow: 1;
+      }
+
+      .control {
+        button {
+          display: block;
+          background-color: transparent;
+          border: 0;
+          padding: 0;
+          cursor: pointer;
+        }
+      }
+      .edit-menu {
+        display: flex;
+        gap: 8px;
+        li {
+          width: 100%;
+          &.register button {
+            color: ${color.text.default};
+          }
+          &.register button {
+            background-color: ${color.surface.brand};
+            color: ${color.text.white.default};
+          }
+        }
+        button {
+          width: 100%;
+        }
+      }
+    `;
+  }}
+`;
+
+export default CardShadow;

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -140,8 +140,8 @@ const allData = [
       {
         id: 2,
         title: "title2",
-        content: "content2",
-        nickname: "nickname2",
+        content: "content",
+        nickname: "nickname",
       },
     ],
   },
@@ -151,34 +151,23 @@ const allData = [
     cards: [
       {
         id: 3,
-        title: "title1",
+        title: "title3",
         content: "content",
         nickname: "nickname",
       },
       {
         id: 4,
-        title: "title2",
-        content: "content2",
-        nickname: "nickname2",
+        title: "title4",
+        content: "content",
+        nickname: "nickname",
       },
     ],
   },
   {
     categoryId: 3,
-    categoryName: "doing",
+    categoryName: "done",
     cards: [
-      {
-        id: 3,
-        title: "title1",
-        content: "content",
-        nickname: "nickname",
-      },
-      {
-        id: 4,
-        title: "title2",
-        content: "content2",
-        nickname: "nickname2",
-      },
+      
     ],
   },
 ];


### PR DESCRIPTION
## 의도 
카드를 다른 칼럼 혹은 같은 칼럼의 다른 위치로 이동시키는 기능 구현

## 구체적으로 봐야하는 포인트, 세부적인 변경점
- Drag 관련 state를 context를 사용해 관리
- 드래그 시 position과 각 카드, 칼럼들의 위치정보를 비교해서 예상 목적지를 계산하는 로직

## 관련 이슈
- #47 